### PR TITLE
ops: Actions workflow to upload website files to GCP bucket

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,49 @@
+name: dev-ci-frontend
+
+on:
+  push:
+    branches: "main"
+  workflow_dispatch:
+
+jobs:
+  upload-website-files:
+    environment: dev
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Inject runtime config
+        env: 
+          API_URL: ${{ vars.API_GW_HOST }}
+        run: |
+          mkdir -p website/js
+          cat > website/js/config.js <<'EOF'
+          window.CONFIG = {
+            API_URL: "${API_URL}"
+          };
+          EOF
+
+      - name: Auth to Google
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+
+      - name: upload-files
+        uses: 'google-github-actions/upload-cloud-storage@v3'
+        with:
+          path: './website'
+          destination: ${{ vars.BUCKET_NAME }}
+          parent: false
+
+      - name: Invalidate CDN
+        run: gcloud compute url-maps invalidate-cdn-cache "${{ vars.URL_MAP_NAME }}" --path "/*" --quiet


### PR DESCRIPTION
# Description
GitHub Actions workflow created to deploy website files to GCP cloud storage bucket and invalidate CDN cache of files
# Jira Key
- CR-4
